### PR TITLE
Add exit to single_letters testcase

### DIFF
--- a/projects/project3/input/single_letters.in
+++ b/projects/project3/input/single_letters.in
@@ -13,3 +13,4 @@ i A
 i B
 i C
 p
+exit


### PR DESCRIPTION
The recently-added single_letters testcase seems to be missing an "exit", which may cause memory unsafety failures — this commit adds that line.